### PR TITLE
Upgraded to async-http-client 1.9.33

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>com.ning</groupId>
       <artifactId>async-http-client</artifactId>
-      <version>1.8.14</version>
+      <version>1.9.33</version>
     </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/client/src/main/java/io/prediction/BaseClient.java
+++ b/client/src/main/java/io/prediction/BaseClient.java
@@ -73,11 +73,11 @@ public abstract class BaseClient implements Closeable {
         this.apiUrl = apiURL;
         // Async HTTP client config
         AsyncHttpClientConfig config = (new AsyncHttpClientConfig.Builder())
-                .setAllowPoolingConnection(true)
-                .setAllowSslConnectionPool(true)
+                .setAllowPoolingConnections(true)
+                .setAllowPoolingSslConnections(true)
                 .addRequestFilter(new ThrottleRequestFilter(threadLimit))
-                .setMaximumConnectionsPerHost(threadLimit)
-                .setRequestTimeoutInMs(timeout * 1000)
+                .setMaxConnectionsPerHost(threadLimit)
+                .setRequestTimeout(timeout * 1000)
                 .setIOThreadMultiplier(threadLimit)
                 .build();
         this.client = new AsyncHttpClient(new NettyAsyncHttpProvider(config), config);


### PR DESCRIPTION
Hello

I upgraded the async-http-client dependency. There's just some minor changes in the API.

The fact that this SDK depends on a 1.8.x version currently prevents us from using it in a Play 2.4 application (which pulls a 1.9.x version of async-http-client, resulting in a not found method error at runtime).

Thx
